### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -145,15 +145,9 @@ any member of the conduct team directly.
 
 ## Conduct team
 
-The conduct team can be emailed at conduct@carbon-lang.dev, and currently has
-the following members:
+The conduct team can be emailed at conduct@carbon-lang.dev.
 
--   Allison Poppe (@acpoppe on Discord and GitHub)
--   Céline Dedaj (@celineausberlin on Discord and GitHub)
--   Christopher Di Bella (@cjdb.work on Discord, @cjdb on GitHub)
--   Lexi Bromfield (@lexinadia on Discord and @lexi-nadia on GitHub)
-
-More details about the team and its management are on the
+More details about the team, its members and its management are on the
 [conduct team page](/docs/project/teams/conduct_team.md).
 
 ### Reporting conduct


### PR DESCRIPTION
Deleted conduct team member list from this page to avoid duplicate information: the list is already on the conduct team page, referenced here.